### PR TITLE
Gulp task renaming

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -311,7 +311,7 @@ function calculateAdjustedUrl(url){
 
 /*------------------------------------------------*/
 
-gulp.task('app:build:styles:src', function(){
+gulp.task('app:build:styles:src:local', function(){
     return gulp.src(srcCss)
         .pipe($.plumber({
             errorHandler: onError
@@ -329,11 +329,11 @@ gulp.task('app:build:styles:src', function(){
         .pipe($.autoprefixer({browsers: AUTOPREFIXER_BROWSERS}))
         .pipe(gulp.dest(dist))
         .pipe(reload({stream: true}))
-        .pipe($.size({title: 'app:build:styles:src'}))
+        .pipe($.size({title: 'app:build:styles:src:local'}))
     ;
 });
 
-gulp.task('app:build:scripts:src', function(){
+gulp.task('app:build:scripts:src:local', function(){
     var files = mainBowerFiles({filter: /\.(js)$/i});
     files.push(srcJs);
 
@@ -359,7 +359,7 @@ gulp.task('app:build:scripts:src', function(){
         .pipe($.concat(concatJsFile))
         .pipe(gulp.dest(distScripts))
         .pipe(reload({stream: true, once: true}))
-        .pipe($.size({title: 'app:build:scripts:src'}))
+        .pipe($.size({title: 'app:build:scripts:src:local'}))
     ;
 });
 
@@ -372,7 +372,7 @@ gulp.task('__app:reload:page', function(){
 
 /*------------------------------------------------*/
 
-gulp.task('compile:css:remote', function(){
+gulp.task('app:build:styles:src:remote', function(){
     return gulp.src(srcCss)
         .pipe($.plumber({
             errorHandler: onError
@@ -389,11 +389,11 @@ gulp.task('compile:css:remote', function(){
         .pipe($.if('*.css', $.csso()))
         .pipe($.autoprefixer({browsers: AUTOPREFIXER_BROWSERS}))
         .pipe(gulp.dest(dist))
-        .pipe($.size({title: 'compile:css:remote'}))
+        .pipe($.size({title: 'app:build:styles:src:remote'}))
     ;
 });
 
-gulp.task('compile:js:remote', function(){
+gulp.task('app:build:scripts:src:remote', function(){
     var files = mainBowerFiles({filter: /\.(js)$/i});
     files.push(srcJs);
 
@@ -428,11 +428,11 @@ gulp.task('compile:js:remote', function(){
         ]))
         .pipe($.concat(concatJsFile))
         .pipe(gulp.dest(distScripts))
-        .pipe($.size({title: 'compile:js:remote'}))
+        .pipe($.size({title: 'app:build:scripts:src:remote'}))
     ;
 });
 
-gulp.task('prepare:css:remote', function(){
+gulp.task('app:prepare:styles:src:remote', function(){
     return gulp.src(srcCss, {base: src})
         .pipe($.plumber({
             errorHandler: onError
@@ -449,7 +449,7 @@ gulp.task('prepare:css:remote', function(){
         .pipe($.if('*.css', $.csso()))
         .pipe($.autoprefixer({browsers: AUTOPREFIXER_BROWSERS}))
         .pipe(gulp.dest(dist))
-        .pipe($.size({title: 'prepare:css:remote'}))
+        .pipe($.size({title: 'app:prepare:styles:src:remote'}))
         .pipe($.if(
             !argv.production,
             $.sftp({
@@ -471,7 +471,7 @@ gulp.task('prepare:css:remote', function(){
     ;
 });
 
-gulp.task('prepare:js:remote', function(){
+gulp.task('app:prepare:scripts:src:remote', function(){
     var files = mainBowerFiles({filter: /\.(js)$/i});
     files.push(srcJs);
 
@@ -506,7 +506,7 @@ gulp.task('prepare:js:remote', function(){
         ]))
         .pipe($.concat(concatJsFile))
         .pipe(gulp.dest(distScripts))
-        .pipe($.size({title: 'prepare:js:remote'}))
+        .pipe($.size({title: 'app:prepare:scripts:src:remote'}))
         .pipe($.if(
             !argv.production,
             $.sftp({
@@ -528,7 +528,7 @@ gulp.task('prepare:js:remote', function(){
     ;
 });
 
-gulp.task('reloadhtmlphpandupload', function(){
+gulp.task('app:reload:pages:dist', function(){
     return gulp.src(htmlPhpFiles, {base: dist})
         .pipe($.plumber({
             errorHandler: onError
@@ -576,7 +576,7 @@ gulp.task('__app:copy:files', function(){
 
 /*------------------------------------------------*/
 
-gulp.task('sftp', function(){
+gulp.task('__app:sftp:dist', function(){
     return gulp.src([dist + '**/*.{' + allValidFileTypes + '}', '!' + currentLevel + 'gulpfile.js'], {dot: true})
         .pipe(plumber({
             errorHandler: onError
@@ -602,7 +602,7 @@ gulp.task('sftp', function(){
     ;
 });
 
-gulp.task('app:serve', function(){
+gulp.task('app:serve:local', function(){
     browserSync({
         proxy: browserSyncProxyUrl,
         notify: false,
@@ -612,14 +612,14 @@ gulp.task('app:serve', function(){
     });
 
     gulp.watch(htmlPhpFiles, ['__app:reload:page']);
-    gulp.watch(srcCss, ['app:build:styles:src']);
-    gulp.watch(srcJs, ['app:build:scripts:src']);
+    gulp.watch(srcCss, ['app:build:styles:src:local']);
+    gulp.watch(srcJs, ['app:build:scripts:src:local']);
 });
 
-gulp.task('serve:remote', function(){
-    gulp.watch(htmlPhpFiles, ['reloadhtmlphpandupload']);
-    gulp.watch(srcCss, ['prepare:css:remote']);
-    gulp.watch(srcJs, ['prepare:js:remote']);
+gulp.task('app:serve:remote', function(){
+    gulp.watch(htmlPhpFiles, ['app:reload:pages:dist']);
+    gulp.watch(srcCss, ['app:prepare:styles:src:remote']);
+    gulp.watch(srcJs, ['app:prepare:scripts:src:remote']);
 });
 
 gulp.task('openurl:remote', function(){
@@ -628,20 +628,20 @@ gulp.task('openurl:remote', function(){
 
 /*------------------------------------------------*/
 
-gulp.task('app:build', function(callback){
-    runSequence('__app:clean:all', ['app:build:styles:src', 'app:build:scripts:src', 'app:build:images:src', '__app:copy:files'], callback);
+gulp.task('app:build:local', function(callback){
+    runSequence('__app:clean:all', ['app:build:styles:src:local', 'app:build:scripts:src:local', 'app:build:images:src', '__app:copy:files'], callback);
 });
 
-gulp.task('build:remote', function(callback){
-    runSequence('__app:clean:all', ['compile:css:remote', 'compile:js:remote', 'app:build:images:src', '__app:copy:files'], callback);
+gulp.task('app:build:remote', function(callback){
+    runSequence('__app:clean:all', ['app:build:styles:src:remote', 'app:build:scripts:src:remote', 'app:build:images:src', '__app:copy:files'], callback);
 });
 
 gulp.task('default', function(callback){
-    runSequence('app:build', 'app:serve', callback);
+    runSequence('app:build:local', 'app:serve:local', callback);
 });
 
-gulp.task('upload', function(callback){
-    runSequence('build:remote', 'sftp', 'serve:remote', 'openurl:remote', callback);
+gulp.task('app:upload:dist', function(callback){
+    runSequence('app:build:remote', '__app:sftp:dist', 'app:serve:remote', 'openurl:remote', callback);
 });
 
 //Load custom tasks from the `tasks` directory (if it exists)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -144,7 +144,7 @@ gulp.task('app:lint:src:jshint', function(){
     ;
 });
 
-gulp.task('app:generate:stats', function(){
+gulp.task('app:generate:src:stats', function(){
     return gulp.src(srcJs)
         .pipe($.complexity())
     ;
@@ -251,14 +251,14 @@ gulp.task('__app:clean:images', function(cb){
     del([dist + '**/*.{' + imageFileTypes + '}'], {'force': true}, cb);
 });
 
-gulp.task('app:process:src:tabs', function(){
+gulp.task('__app:process:src:tabs', function(){
     return gulp.src(htmlPhpFiles)
         .pipe($.soften(4)) //4 spaces
         .pipe(gulp.dest(dist))
     ;
 });
 
-gulp.task('app:process:src:eol', function(){
+gulp.task('__app:process:src:eol', function(){
     return gulp.src(htmlPhpFiles)
         .pipe($.eol('\r\n', false))
         .pipe(gulp.dest(dist))
@@ -266,7 +266,7 @@ gulp.task('app:process:src:eol', function(){
 });
 
 gulp.task('__app:clean:all', function(callback){
-    return runSequence(['app:process:src:tabs', 'app:process:src:eol'], '__app:clean:styles', '__app:clean:scripts', '__app:clean:images', callback);
+    return runSequence(['__app:process:src:tabs', '__app:process:src:eol'], '__app:clean:styles', '__app:clean:scripts', '__app:clean:images', callback);
 });
 
 /*------------------------------------------------*/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -144,7 +144,7 @@ gulp.task('app:lint:src:jshint', function(){
     ;
 });
 
-gulp.task('stats', function(){
+gulp.task('app:generate:stats', function(){
     return gulp.src(srcJs)
         .pipe($.complexity())
     ;
@@ -222,7 +222,7 @@ gulp.task('bower:install', function(){
         });
 });
 
-gulp.task('critical:css', function(){
+gulp.task('app:build:styles:src:critical', function(){
     penthouse({
         url: browserSyncProxyUrl, //localhost
         css: srcStyles + '/screen.css', //main CSS file
@@ -363,7 +363,7 @@ gulp.task('app:build:scripts:src:local', function(){
     ;
 });
 
-gulp.task('__app:reload:page', function(){
+gulp.task('__app:reload:pages:local', function(){
     return gulp.src(htmlPhpFiles)
         .pipe($.changed(htmlPhpFiles))
         .pipe(reload({stream: true}))
@@ -528,7 +528,7 @@ gulp.task('app:prepare:scripts:src:remote', function(){
     ;
 });
 
-gulp.task('app:reload:pages:dist', function(){
+gulp.task('__app:reload:pages:remote', function(){
     return gulp.src(htmlPhpFiles, {base: dist})
         .pipe($.plumber({
             errorHandler: onError
@@ -611,18 +611,18 @@ gulp.task('app:serve:local', function(){
         }
     });
 
-    gulp.watch(htmlPhpFiles, ['__app:reload:page']);
+    gulp.watch(htmlPhpFiles, ['__app:reload:pages:local']);
     gulp.watch(srcCss, ['app:build:styles:src:local']);
     gulp.watch(srcJs, ['app:build:scripts:src:local']);
 });
 
 gulp.task('app:serve:remote', function(){
-    gulp.watch(htmlPhpFiles, ['app:reload:pages:dist']);
+    gulp.watch(htmlPhpFiles, ['__app:reload:pages:remote']);
     gulp.watch(srcCss, ['app:prepare:styles:src:remote']);
     gulp.watch(srcJs, ['app:prepare:scripts:src:remote']);
 });
 
-gulp.task('openurl:remote', function(){
+gulp.task('app:open:dist:remote', function(){
     return argv.production ? open(remoteBaseProdUrl, webBrowser) : open(remoteBaseDevUrl, webBrowser);
 });
 
@@ -641,7 +641,7 @@ gulp.task('default', function(callback){
 });
 
 gulp.task('app:upload:dist', function(callback){
-    runSequence('app:build:remote', '__app:sftp:dist', 'app:serve:remote', 'openurl:remote', callback);
+    runSequence('app:build:remote', '__app:sftp:dist', 'app:serve:remote', 'app:open:dist:remote', callback);
 });
 
 //Load custom tasks from the `tasks` directory (if it exists)


### PR DESCRIPTION
The general task structure of the gulpfile has been refactored to provide a more consistent task naming scheme. This is done as follows:

`app:<verb>:<noun>:(src|dist):<additional>`

---

Reuse of `onError()` function

