### PR TITLE
Remove changed filter

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -382,7 +382,6 @@ gulp.task('app:build:styles:src:local', function(){
         .pipe($.plumber({
             errorHandler: onError
         }))
-        .pipe($.changed(dist)) //must be dist
         .pipe($.tap(function(file, t){
             currentFile = file.path; //update global var
         }))


### PR DESCRIPTION
Using `$.changed` was causing an issue where bootstrap would be missed out on initial build when starting gulp (however saving a file would then include bootstrap in the resulting minified CSS file). Resolves #34.