### PR TITLE
Enable multiple build targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,18 @@ $ gulp bower:install
 
 ---
 
+##Creating multiple build targets
+
+A custom build target should have a separate `config_custom_target_name.json` file.
+
+Usage example:
+```
+gulp --load-config custom_target_name
+```
+Makes gulp use the values from `config_custom_target_name.json` in order to create a custom build target.
+
+---
+
 ## License
 
 [MIT](http://opensource.org/licenses/MIT) © [Jonathan Goode](http://jonathangoode.co.uk)

--- a/README.md
+++ b/README.md
@@ -240,14 +240,16 @@ $ gulp bower:install
 
 ---
 
-##Creating multiple build targets
+## Creating Multiple Build Targets
 
 A custom build target should have a separate `config_custom_target_name.json` file.
 
 Usage example:
+
+```sh
+$ gulp --load-config custom_target_name
 ```
-gulp --load-config custom_target_name
-```
+
 Makes gulp use the values from `config_custom_target_name.json` in order to create a custom build target.
 
 ---

--- a/README.md
+++ b/README.md
@@ -242,15 +242,15 @@ $ gulp bower:install
 
 ## Creating Multiple Build Targets
 
-A custom build target should have a separate `config_custom_target_name.json` file.
+A custom build target should have a separate `config_custom_target.json` file.
 
 Usage example:
 
 ```sh
-$ gulp --load-config custom_target_name
+$ gulp --load-config custom_target
 ```
 
-Makes gulp use the values from `config_custom_target_name.json` in order to create a custom build target.
+Makes Gulp use the values from `config_custom_target.json` in order to create a custom build target.
 
 ---
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -447,12 +447,12 @@ function calculateAdjustedUrl(url){
     return output;
 }
 
-function loadBowerFiles() {
+function loadBowerFiles(){
     var files = [];
     if(!config.customBowerFiles){
         files = mainBowerFiles({filter: /\.(js)$/i});
     } else {
-        files = config.customBowerFiles.map(function(bowerFile) {
+        files = config.customBowerFiles.map(function(bowerFile){
             return config.folderSettings.bowerComponents + '/' + bowerFile;
         });
     }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,7 @@ var currentLevel = './',
 // This cannot be done via the node module argv because the config needs to be loaded before the node_modules are loaded
 var loadConfig = process.argv.indexOf('--load-config'),
     configFilename;
-if (loadConfig === -1) {
+if(loadConfig === -1){
     configFilename = 'config.json';
 } else {
     var loadConfigValueIndex = loadConfig + 1;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -449,7 +449,7 @@ function calculateAdjustedUrl(url){
 
 function loadBowerFiles() {
     var files = [];
-    if (!config.customBowerFiles) {
+    if(!config.customBowerFiles){
         files = mainBowerFiles({filter: /\.(js)$/i});
     } else {
         files = config.customBowerFiles.map(function(bowerFile) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -447,6 +447,18 @@ function calculateAdjustedUrl(url){
     return output;
 }
 
+function loadBowerFiles() {
+    var files = [];
+    if (!config.customBowerFiles) {
+        files = mainBowerFiles({filter: /\.(js)$/i});
+    } else {
+        files = config.customBowerFiles.map(function(bowerFile) {
+            return config.folderSettings.bowerComponents + '/' + bowerFile;
+        });
+    }
+    return files;
+}
+
 /*------------------------------------------------*/
 
 gulp.task('app:build:styles:src:local', function(){
@@ -478,7 +490,7 @@ gulp.task('app:install:scripts:src:local', function(callback){
 });
 
 gulp.task('app:build:scripts:src:local', function(){
-    var files = mainBowerFiles({filter: /\.(js)$/i});
+    var files = loadBowerFiles();
     files.push(srcJs);
 
     var scriptsConcatenationOrder = buildScriptsConcatenationOrder(config.scriptSettings.concatenation.order);
@@ -543,7 +555,7 @@ gulp.task('app:install:scripts:src:remote', function(callback){
 });
 
 gulp.task('app:build:scripts:src:remote', function(){
-    var files = mainBowerFiles({filter: /\.(js)$/i});
+    var files = loadBowerFiles();
     files.push(srcJs);
 
     var scriptsConcatenationOrder = buildScriptsConcatenationOrder(config.scriptSettings.concatenation.order);
@@ -621,7 +633,7 @@ gulp.task('app:prepare:styles:src:remote', function(){
 });
 
 gulp.task('app:prepare:scripts:src:remote', function(){
-    var files = mainBowerFiles({filter: /\.(js)$/i});
+    var files = loadBowerFiles();
     files.push(srcJs);
 
     var scriptsConcatenationOrder = buildScriptsConcatenationOrder(config.scriptSettings.concatenation.order);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,8 @@
 * @code --skipPageOpen   Skip BrowserSync opening a web page on completion of Gulp tasks
 * @code --skipWatch      Skip all watch tasks (supersedes --skipBowerWatch)
 *
+* @code --loadConfig     Sets the config for a specific target admin
+*
 * @code --production     Run tasks as production ready (e.g. force minification, etc.)
 * @code --verbose        Per task, output each file that is processed in the stream
 */
@@ -15,7 +17,18 @@
 var currentLevel = './',
     upOneLevel = '../';
 
-var config = require(currentLevel + 'config.json');
+// Check if the '--load-config' argument is supplied
+// This cannot be done via argv since the config needs to be loaded before the node_modules are loaded
+var loadConfig = process.argv.indexOf('--load-config'),
+    configFilename;
+if (loadConfig === -1) {
+    configFilename = 'config.json';
+} else {
+    var loadConfigValueIndex = loadConfig + 1;
+    var configFilename = (!!process.argv[loadConfigValueIndex]) ? 'config_' + process.argv[loadConfigValueIndex] + '.json' : 'config.json';
+} 
+
+var config = require(currentLevel + configFilename);
 
 var node_modules = '',
     composer_bin = '',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,7 +26,7 @@ if(loadConfig === -1){
 } else {
     var loadConfigValueIndex = loadConfig + 1;
     var configFilename = (!!process.argv[loadConfigValueIndex]) ? 'config_' + process.argv[loadConfigValueIndex] + '.json' : 'config.json';
-} 
+}
 
 var config = require(currentLevel + configFilename);
 
@@ -842,4 +842,4 @@ gulp.task('app:upload:dist', function(callback){
 });
 
 //Load custom tasks from the `tasks` directory (if it exists)
-try { require(node_modules + 'require-dir')('tasks'); } catch (error) { onError(error); }
+try { require(node_modules + 'require-dir')('tasks'); } catch(error){ onError(error); }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,7 @@
 * @code --skipPageOpen   Skip BrowserSync opening a web page on completion of Gulp tasks
 * @code --skipWatch      Skip all watch tasks (supersedes --skipBowerWatch)
 *
-* @code --loadConfig     Sets the config for a specific target admin
+* @code --loadConfig     Sets the config for a specific target (i.e `gulp --load-config customtarget` makes gulp use `config_customtarget.json`)
 *
 * @code --production     Run tasks as production ready (e.g. force minification, etc.)
 * @code --verbose        Per task, output each file that is processed in the stream
@@ -18,7 +18,7 @@ var currentLevel = './',
     upOneLevel = '../';
 
 // Check if the '--load-config' argument is supplied
-// This cannot be done via argv since the config needs to be loaded before the node_modules are loaded
+// This cannot be done via the node module argv because the config needs to be loaded before the node_modules are loaded
 var loadConfig = process.argv.indexOf('--load-config'),
     configFilename;
 if (loadConfig === -1) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,7 @@
 * @code --skipPageOpen   Skip BrowserSync opening a web page on completion of Gulp tasks
 * @code --skipWatch      Skip all watch tasks (supersedes --skipBowerWatch)
 *
-* @code --loadConfig     Sets the config for a specific target (i.e `gulp --load-config customtarget` makes gulp use `config_customtarget.json`)
+* @code --loadConfig     Sets the config for a specific target (e.g. `gulp --load-config custom_target` makes Gulp use `config_custom_target.json`)
 *
 * @code --production     Run tasks as production ready (e.g. force minification, etc.)
 * @code --verbose        Per task, output each file that is processed in the stream


### PR DESCRIPTION
- Add the ability to have multiple configuration files
- Add the ability to create a whitelist for the scripts inside `bower_components`